### PR TITLE
Verify proxy logic and functionality

### DIFF
--- a/src/main/services/config-service.js
+++ b/src/main/services/config-service.js
@@ -104,6 +104,7 @@ class ConfigService {
       maxTokens: config.maxTokens || 4000,
       temperature: config.temperature || 0,
       proxy: config.proxy || '',
+      useInternalProxy: config.useInternalProxy === true ? true : false,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       ...config


### PR DESCRIPTION
Add `useInternalProxy` flag to allow direct connection to external proxy providers, avoiding double proxying.

The previous implementation would always start a local proxy if `apiUrl` was not the default Anthropic API, leading to an unnecessary local proxy layer when an external provider (like `fuergaosi233/claude-code-proxy`) was intended to be used directly. This change introduces a flag to explicitly control the internal proxy's activation, ensuring that when `useInternalProxy` is false, the Claude CLI connects directly to the configured `apiUrl`.

---
<a href="https://cursor.com/background-agent?bcId=bc-99a938df-717c-4b5d-a770-b5963c3d0406">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99a938df-717c-4b5d-a770-b5963c3d0406">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

